### PR TITLE
Feature/#32 - Implement PDF to Markdown

### DIFF
--- a/globook_server/.gitignore
+++ b/globook_server/.gitignore
@@ -264,3 +264,5 @@ HELP.md
 application.yml
 application-dev.yml
 application-local.yml
+
+solutionchallenge-globook-a47f1971726c.json

--- a/globook_server/build.gradle
+++ b/globook_server/build.gradle
@@ -43,9 +43,18 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
 
+	// Google Cloud Platform Storage
+	implementation 'com.google.cloud:google-cloud-storage:2.52.1'
+	implementation 'com.google.cloud:google-cloud-storage-control:2.52.1'
+
+	// Google TTS 라이브러리
+	implementation 'com.google.cloud:google-cloud-texttospeech:2.19.0'
+
 	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.reactivestreams:reactive-streams:1.0.4'
 }
 
 tasks.named('test') {

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/MarkdownConversionResult.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/MarkdownConversionResult.java
@@ -1,0 +1,9 @@
+package org.gdsc.globook.application.dto;
+
+import java.util.Map;
+
+public record MarkdownConversionResult(
+        String markdown,
+        Map<String, String> images
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownPollingRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownPollingRequestDto.java
@@ -1,0 +1,12 @@
+package org.gdsc.globook.application.dto;
+
+import java.util.Map;
+
+public record PdfToMarkdownPollingRequestDto(
+        String markdown,
+        Boolean success,
+        Map<String, String> images,
+        String targetLanguage,
+        String persona
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownRequestDto.java
@@ -1,0 +1,9 @@
+package org.gdsc.globook.application.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record PdfToMarkdownRequestDto(
+        MultipartFile file,
+        String langs
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResponseDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResponseDto.java
@@ -1,0 +1,10 @@
+package org.gdsc.globook.application.dto;
+
+import java.util.Map;
+
+public record PdfToMarkdownResponseDto(
+        String markdown,
+        Boolean success,
+        Map<String, String> images
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResponsePollingDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResponsePollingDto.java
@@ -1,0 +1,8 @@
+package org.gdsc.globook.application.dto;
+
+public record PdfToMarkdownResponsePollingDto(
+        Boolean success,
+        String error,
+        String request_check_url
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/TTSRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/TTSRequestDto.java
@@ -1,0 +1,37 @@
+package org.gdsc.globook.application.dto;
+
+import lombok.Builder;
+import org.gdsc.globook.domain.type.ELanguage;
+import org.gdsc.globook.domain.type.EPersona;
+
+@Builder
+public record TTSRequestDto(
+        Input input,
+        Voice voice,
+        AudioConfig audioConfig
+) {
+    public static TTSRequestDto from(String inputString, ELanguage language, EPersona persona){
+        return TTSRequestDto.builder()
+                .input(new Input(inputString))
+                .voice(new Voice(language.getLanguageCode(), persona.getGender()))
+                .audioConfig(new AudioConfig("MP3", persona.getSpeakingRate(), persona.getPitch())).build();
+    }
+}
+
+record Input(
+        String text
+) {
+}
+
+record Voice(
+        String languageCode,
+        String ssmlGender
+) {
+}
+
+record AudioConfig(
+        String audioEncoding,
+        Double speakingRate,
+        Double pitch
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/TTSResponseDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/TTSResponseDto.java
@@ -1,0 +1,6 @@
+package org.gdsc.globook.application.dto;
+
+public record TTSResponseDto(
+        String audioContent
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/UploadPdfRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/UploadPdfRequestDto.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.dto;
+
+public record UploadPdfRequestDto(
+        String targetLanguage,
+        String persona
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Candidate.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Candidate.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.dto.gemini;
+
+
+public record Candidate(
+        Content content
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Content.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Content.java
@@ -1,0 +1,8 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import java.util.List;
+
+public record Content(
+        List<Part> parts
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GeminiResponseDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GeminiResponseDto.java
@@ -1,0 +1,9 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import java.util.List;
+
+public record GeminiResponseDto(
+        List<Candidate> candidates
+) {
+}
+

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GeneralizeParagraphRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GeneralizeParagraphRequestDto.java
@@ -1,0 +1,38 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GeneralizeParagraphRequestDto(
+        SystemInstruction systemInstruction,
+        List<Content> contents,
+        GenerationConfig generationConfig
+) {
+    private static final Part prompt1
+            = new Part("당신은 마크다운을 문자열을 일반 문자열로 반환하는 챗봇입니다. 다른 사족 없이 일반 문자열만 반환합니다.");
+    private static final Part prompt2
+            = new Part("""
+            입력값은 마크다운 문자열로만 주어집니다.
+            다음과 같은 규칙에 따라 마크다운을 일반 문자열로 변환합니다.
+            
+            1. 일반적인 문자열로 생각되게끔 마크다운 문법은 전부 지우고 일반 문자열을 만들어냅니다.
+            2. 마크다운 내 이미지 등 일반 문자열로 바꾸기 어렵다고 생각되는 부분은 그냥 지워버립니다.
+            3. 스스로 잘 만들어냈는지 고민해야합니다.
+            """);
+    private static final List<Part> SYSTEM_PARTS
+            = List.of(prompt1, prompt2);
+    private static final SystemInstruction DEFAULT_SYSTEM_INSTRUCTION
+            = new SystemInstruction(SYSTEM_PARTS);
+
+    public static GeneralizeParagraphRequestDto from(String markdown) {
+        Part inputMessageToGemini = new Part(markdown);
+        Content content = new Content(List.of(inputMessageToGemini));
+
+        return GeneralizeParagraphRequestDto.builder()
+                .systemInstruction(DEFAULT_SYSTEM_INSTRUCTION)
+                .contents(List.of(content))
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GenerationConfig.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/GenerationConfig.java
@@ -1,0 +1,9 @@
+package org.gdsc.globook.application.dto.gemini;
+
+
+public record GenerationConfig(
+        Integer maxOutputTokens,
+        String responseMimeType,
+        ResponseSchema responseSchema
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Item.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Item.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.dto.gemini;
+
+
+public record Item(
+        String type
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/MarkdownToParagraphGeminiRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/MarkdownToParagraphGeminiRequestDto.java
@@ -1,0 +1,44 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MarkdownToParagraphGeminiRequestDto(
+        SystemInstruction systemInstruction,
+        List<Content> contents,
+        GenerationConfig generationConfig
+) {
+    private static final Part prompt1
+            = new Part("당신은 마크다운을 문자열 배열로 잘라 반환하는 챗봇입니다. 다른 사족 없이 잘라진 배열로만 반환합니다.");
+    private static final Part prompt2
+            = new Part("""
+            입력값은 마크다운 문자열로만 주어집니다.
+            다음과 같은 규칙에 따라 마크다운을 문자열 배열로 잘라냅니다.
+            
+            1. 넉넉하게 3문장 ~ 4문장 크기로 잘라냅니다.
+            2. 마크다운 내 표, 리스트 형태 등 정보를 잘랐을 때 이상해질 것 같은 부분은 따로 자르지 않습니다.
+            3. 어색하지 않고 자연스럽게 잘라내야 하며, 스스로 잘 만들어냈는지 고민해야합니다.
+            """);
+    private static final List<Part> SYSTEM_PARTS
+            = List.of(prompt1, prompt2);
+    private static final SystemInstruction DEFAULT_SYSTEM_INSTRUCTION
+            = new SystemInstruction(SYSTEM_PARTS);
+    private static final ResponseSchema RESPONSE_SCHEMA
+            = new ResponseSchema("ARRAY", new Item("STRING"));
+    private static final GenerationConfig GENERATION_CONFIG
+            = new GenerationConfig(16384,"application/json", RESPONSE_SCHEMA);
+
+    public static MarkdownToParagraphGeminiRequestDto from(String markdown) {
+        Part inputMessageToGemini = new Part(markdown);
+        Content content = new Content(List.of(inputMessageToGemini));
+
+        return MarkdownToParagraphGeminiRequestDto.builder()
+                .systemInstruction(DEFAULT_SYSTEM_INSTRUCTION)
+                .contents(List.of(content))
+                .generationConfig(GENERATION_CONFIG)
+                .build();
+    }
+}
+

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Part.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/Part.java
@@ -1,0 +1,6 @@
+package org.gdsc.globook.application.dto.gemini;
+
+public record Part(
+        String text
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/ResponseSchema.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/ResponseSchema.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.dto.gemini;
+
+public record ResponseSchema(
+        String type,
+        Item items
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/SystemInstruction.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/SystemInstruction.java
@@ -1,0 +1,8 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import java.util.List;
+
+public record SystemInstruction(
+        List<Part> parts
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/TranslateGeminiRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/gemini/TranslateGeminiRequestDto.java
@@ -1,0 +1,38 @@
+package org.gdsc.globook.application.dto.gemini;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TranslateGeminiRequestDto(
+        SystemInstruction systemInstruction,
+        List<Content> contents,
+        GenerationConfig generationConfig
+) {
+    private static final Part prompt1
+            = new Part("당신은 마크다운을 문자열을 다른 언어로 번역해주는 챗봇입니다. 다른 사족 없이 번역된 문자열만 반환합니다.");
+    private static final Part prompt2
+            = new Part("""
+            입력값은 마크다운 문자열로만 주어집니다.
+            다음과 같은 규칙에 따라 입력된 마크다운 문자열을 번역합니다.
+            
+            1. 마크다운 문법 요소(예: 코드 블럭, 표, 이미지, 링크)는 절대로 번역하지 말 것.
+            2. 마크다운 문법 요소 내부에 포함된 텍스트도 변형하지 말 것. (예: 코드 블럭 안의 코드 등.)
+            3. 단락 간의 구조, 줄바꿈 등 원본의 형식을 최대한 보존할 것.
+            """);
+    private static final List<Part> SYSTEM_PARTS
+            = List.of(prompt1, prompt2);
+    private static final SystemInstruction DEFAULT_SYSTEM_INSTRUCTION
+            = new SystemInstruction(SYSTEM_PARTS);
+
+    public static TranslateGeminiRequestDto from(String markdown) {
+        Part inputMessageToGemini = new Part(markdown);
+        Content content = new Content(List.of(inputMessageToGemini));
+
+        return TranslateGeminiRequestDto.builder()
+                .systemInstruction(DEFAULT_SYSTEM_INSTRUCTION)
+                .contents(List.of(content))
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/MarkdownToParagraphPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/MarkdownToParagraphPort.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.port;
+
+import java.util.List;
+
+public interface MarkdownToParagraphPort {
+    List<String> convertMarkdownToParagraph(String markdown);
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/PdfToMarkdownPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/PdfToMarkdownPort.java
@@ -1,0 +1,12 @@
+package org.gdsc.globook.application.port;
+
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface PdfToMarkdownPort {
+    PdfToMarkdownResponseDto convertPdfToMarkdown(
+            MultipartFile file
+    );
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
@@ -1,0 +1,13 @@
+package org.gdsc.globook.application.port;
+
+import org.gdsc.globook.application.dto.UploadPdfRequestDto;
+
+public interface TTSPort {
+    String convertTextToSpeech(
+            Long userId,
+            Long fileId,
+            String inputText,
+            Long paragraphId,
+            UploadPdfRequestDto request
+    );
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
@@ -1,0 +1,13 @@
+package org.gdsc.globook.application.port;
+
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.domain.type.ELanguage;
+
+public interface TranslateMarkdownPort {
+    String translateMarkdown(
+            Long userId,
+            Long fileId,
+            PdfToMarkdownResponseDto markdown,
+            ELanguage targetLanguage
+    );
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/repository/ParagraphRepository.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/repository/ParagraphRepository.java
@@ -1,0 +1,7 @@
+package org.gdsc.globook.application.repository;
+
+import org.gdsc.globook.domain.entity.Paragraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParagraphRepository extends JpaRepository<Paragraph, Long> {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/service/FileService.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/service/FileService.java
@@ -5,15 +5,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gdsc.globook.application.dto.PDFListResponseDto;
 import org.gdsc.globook.application.dto.PDFSummaryResponseDto;
+import org.gdsc.globook.application.dto.UploadPdfRequestDto;
 import org.gdsc.globook.application.repository.FileRepository;
 import org.gdsc.globook.application.repository.UserRepository;
 import org.gdsc.globook.core.exception.CustomException;
 import org.gdsc.globook.core.exception.GlobalErrorCode;
 import org.gdsc.globook.domain.entity.File;
 import org.gdsc.globook.domain.entity.User;
+import org.gdsc.globook.domain.type.ELanguage;
+import org.gdsc.globook.domain.type.EPersona;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -21,6 +25,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class FileService {
     private final FileRepository fileRepository;
     private final UserRepository userRepository;
+
+    @Transactional
+    public Long createFile(
+            Long userId,
+            MultipartFile file,
+            UploadPdfRequestDto request
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND_USER));
+
+        // IllegalArgumentException 처리 해줘야됨
+        return fileRepository.save(
+                File.create(
+                        file.getOriginalFilename(),
+                        user,
+                        EPersona.valueOf(request.persona()),
+                        0L,
+                        ELanguage.valueOf(request.targetLanguage())
+                )
+        ).getId();
+    }
 
     @Transactional(readOnly = true)
     public PDFListResponseDto getUploadedFileList(Long userId, Integer size) {

--- a/globook_server/src/main/java/org/gdsc/globook/application/service/GcsService.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/service/GcsService.java
@@ -1,0 +1,35 @@
+package org.gdsc.globook.application.service;
+
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GcsService {
+    @Value("${cloud.storage.bucket}")
+    private String BUCKET_NAME;
+    private final Storage storage;
+
+    public void uploadFile(MultipartFile file) throws IOException {
+        String fileName = file.getOriginalFilename();
+        UUID uuid = UUID.randomUUID();
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, fileName + uuid)
+                .setContentType(file.getContentType())
+                .build();
+
+        storage.create(blobInfo, file.getBytes());
+    }
+
+    public String getPublicImageUrl(String fileName) {
+        return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, fileName);
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/service/GeminiService.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/service/GeminiService.java
@@ -1,0 +1,36 @@
+package org.gdsc.globook.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiService {
+    private final RestClient geminiRestClient;
+
+    Map<String, Object> requestBody = Map.of(
+            "contents", List.of(
+                    Map.of("parts", List.of(
+                            Map.of("text", """
+                                    테스트입니다.
+                                    """)
+                    ))
+            )
+    );
+
+    public void test(String test) {
+
+        String response = geminiRestClient.post().body(requestBody).retrieve().body(String.class);
+
+        log.info(response);
+    }
+
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/service/ParagraphService.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/service/ParagraphService.java
@@ -1,0 +1,87 @@
+package org.gdsc.globook.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.UploadPdfRequestDto;
+import org.gdsc.globook.application.port.MarkdownToParagraphPort;
+import org.gdsc.globook.application.port.PdfToMarkdownPort;
+import org.gdsc.globook.application.port.TTSPort;
+import org.gdsc.globook.application.port.TranslateMarkdownPort;
+import org.gdsc.globook.application.repository.FileRepository;
+import org.gdsc.globook.application.repository.ParagraphRepository;
+import org.gdsc.globook.core.exception.CustomException;
+import org.gdsc.globook.core.exception.GlobalErrorCode;
+import org.gdsc.globook.domain.entity.File;
+import org.gdsc.globook.domain.entity.Paragraph;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ParagraphService {
+    private final PdfToMarkdownPort pdfToMarkdownPort;
+    private final MarkdownToParagraphPort markdownToParagraphPort;
+    private final TranslateMarkdownPort translateMarkdownPort;
+    private final TTSPort ttsPort;
+    private final FileRepository fileRepository;
+    private final ParagraphRepository paragraphRepository;
+
+    @Transactional
+    public PdfToMarkdownResponseDto convertMarkdown(
+            MultipartFile file,
+            Long fileId
+    ) {
+        // 1. pdf 를 마크다운으로 전환
+        PdfToMarkdownResponseDto markdownConversionResult = pdfToMarkdownPort.convertPdfToMarkdown(file);
+
+        // 3. 정상적으로 변경되었다면 file 의 status 변경
+        File updateStatusFile = fileRepository.findById(fileId)
+                .orElseThrow(() -> CustomException.type(GlobalErrorCode.NOT_FOUND_FILE));
+        updateStatusFile.updateFileStatus();
+
+        return markdownConversionResult;
+    }
+
+    @Transactional
+    public void createParagraphForFile(
+            PdfToMarkdownResponseDto markdownConversionResult,
+            Long userId,
+            Long fileId,
+            UploadPdfRequestDto request
+    ) {
+        // 0. 파일 찾기
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> CustomException.type(GlobalErrorCode.NOT_FOUND_FILE));
+
+        // 1. 마크다운 내 이미지 url 처리 & 마크다운을 targetLanguage 로 번역
+        String markdown = translateMarkdownPort.translateMarkdown(
+                userId,
+                fileId,
+                markdownConversionResult,
+                file.getLanguage()
+        );
+
+        // 2. 마크다운을 문단으로 분리
+        List<String> paragraphTextList =  markdownToParagraphPort.convertMarkdownToParagraph(markdown);
+
+        // 각각의 paragraph 생성중
+        for(int index = 0; index < paragraphTextList.size(); index++) {
+            // 3. 마크다운을 문단으로 분리후 paragraph 내에 저장
+            String text = paragraphTextList.get(index);
+            Paragraph paragraph = Paragraph.createFileParagraph(text, (long)index,"", file);
+            paragraphRepository.save(paragraph);
+
+            // 4. 각각의 문단을 일반 문자열로 전환 후 paragraph 업데이트
+            String audioUrl = ttsPort.convertTextToSpeech(
+                    userId, fileId, paragraph.getContent(), paragraph.getId(), request
+            );
+            paragraph.updateAudioUrl(audioUrl);
+            file.updateFileStatus();
+        }
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/core/config/GcsConfig.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/config/GcsConfig.java
@@ -1,0 +1,32 @@
+package org.gdsc.globook.core.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class GcsConfig {
+    @Value("${cloud.storage.credentials.location}")
+    private String resourceJson;
+
+    @Value("${cloud.storage.project-id}")
+    private String projectId;
+
+    @Bean
+    public Storage storage() throws IOException {
+        ClassPathResource resource = new ClassPathResource(resourceJson);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+
+        return StorageOptions.newBuilder()
+                .setProjectId(projectId)
+                .setCredentials(credentials)
+                .build()
+                .getService();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/core/config/GeminiConfig.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/config/GeminiConfig.java
@@ -1,0 +1,23 @@
+package org.gdsc.globook.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GeminiConfig {
+    @Value("${gemini.api.key}")
+    private String geminiAiKey;
+
+    @Value("${gemini.api.url}")
+    private String geminiUrl;
+
+    @Bean
+    public RestClient geminiRestClient() {
+        return RestClient.builder()
+                .baseUrl(geminiUrl + geminiAiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/core/config/PdfConfig.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/config/PdfConfig.java
@@ -1,0 +1,32 @@
+package org.gdsc.globook.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class PdfConfig {
+    @Value("${pdf.api.key}")
+    private String pdfApiKey;
+
+    @Value("${pdf.api.url}")
+    private String pdfUrl;
+
+    @Bean
+    public RestClient pdfRestClient() {
+        return RestClient.builder()
+                .baseUrl(pdfUrl)
+                .defaultHeader("X-Api-Key", pdfApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    @Bean
+    public RestClient getMdRestClient() {
+        return RestClient.builder()
+                .defaultHeader("X-Api-Key", pdfApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/core/config/TTSConfig.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/config/TTSConfig.java
@@ -1,0 +1,23 @@
+package org.gdsc.globook.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class TTSConfig {
+    @Value("${tts.api.key}")
+    private String ttsApiKey;
+
+    @Value("${tts.api.url}")
+    private String ttsUrl;
+
+    @Bean
+    public RestClient ttsRestClient() {
+        return RestClient.builder()
+                .baseUrl(ttsUrl + ttsApiKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/core/exception/GlobalErrorCode.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/exception/GlobalErrorCode.java
@@ -40,6 +40,7 @@ public enum GlobalErrorCode implements ErrorCode{
     NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "지원하지 않는 URL 입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
     NOT_FOUND_BOOK(HttpStatus.NOT_FOUND, "존재하지 않는 도서입니다."),
+    NOT_FOUND_FILE(HttpStatus.NOT_FOUND, "존재하지 않는 파일입니다."),
 
     /**
      * 405 : 지원하지 않는 HTTP Method

--- a/globook_server/src/main/java/org/gdsc/globook/domain/entity/File.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/entity/File.java
@@ -90,4 +90,16 @@ public class File {
                 .maxIndex(maxIndex)
                 .build();
     }
+
+    public void updateFileStatus() {
+        if(this.fileStatus == EFileStatus.UPLOAD) {
+            fileStatus = EFileStatus.PROCESSING;
+        } else if(this.fileStatus == EFileStatus.PROCESSING) {
+            fileStatus = EFileStatus.READ;
+        }
+    }
+
+    public void updateStatusFail() {
+
+    }
 }

--- a/globook_server/src/main/java/org/gdsc/globook/domain/entity/Paragraph.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/entity/Paragraph.java
@@ -73,4 +73,8 @@ public class Paragraph {
                 .file(file)
                 .build();
     }
+
+    public void updateAudioUrl(String audioUrl) {
+        this.audioUrl = audioUrl;
+    }
 }

--- a/globook_server/src/main/java/org/gdsc/globook/domain/type/ELanguage.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/type/ELanguage.java
@@ -1,19 +1,22 @@
 package org.gdsc.globook.domain.type;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum ELanguage {
-    KO("KOREAN"),
-    EN("ENGLISH"),
-    JA("JAPANESE"),
-    ZH("CHINESE"),
-    ES("SPANISH"),
-    FR("FRENCH"),
-    DE("GERMAN"),
-    IT("ITALIAN"),
-    PT("PORTUGUESE"),
-    RU("RUSSIAN");
+    KO("KOREAN", "ko"),
+    EN("ENGLISH", "en"),
+    JA("JAPANESE", "ja"),
+    ZH("CHINESE", "zh"),
+    ES("SPANISH", "es"),
+    FR("FRENCH", "fr"),
+    DE("GERMAN", "de"),
+    IT("ITALIAN", "it"),
+    PT("PORTUGUESE", "pt"),
+    RU("RUSSIAN", "ru");
 
     private final String language;
+    private final String languageCode;
 }

--- a/globook_server/src/main/java/org/gdsc/globook/domain/type/EPersona.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/type/EPersona.java
@@ -1,15 +1,20 @@
 package org.gdsc.globook.domain.type;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum EPersona {
-    ETHAN("ETHAN"),
-    LUNA("LUNA"),
-    KAI("KAI"),
-    SORA("SORA"),
-    NOAH("NOAH"),
-    ARIA("ARIA");
+    ETHAN("ETHAN", "MALE", 1.0, 1.0),
+    LUNA("LUNA", "FEMALE", 1.0, 1.0),
+    KAI("KAI", "MALE", 1.0, 1.0),
+    SORA("SORA", "FEMALE", 1.0, 1.0),
+    NOAH("NOAH", "MALE", 1.0, 1.0),
+    ARIA("ARIA", "FEMALE", 1.0, 1.0);
 
     private final String persona;
+    private final String gender;
+    private final Double speakingRate;
+    private final Double pitch;
 }

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/MarkdownToParagraphAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/MarkdownToParagraphAdapter.java
@@ -1,0 +1,56 @@
+package org.gdsc.globook.infrastructure.adapter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gdsc.globook.application.dto.gemini.GeminiResponseDto;
+import org.gdsc.globook.application.dto.gemini.MarkdownToParagraphGeminiRequestDto;
+import org.gdsc.globook.application.port.MarkdownToParagraphPort;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarkdownToParagraphAdapter implements MarkdownToParagraphPort {
+    private final RestClient geminiRestClient;
+
+    @Override
+    public List<String> convertMarkdownToParagraph(String markdown) {
+        log.info("마크다운을 각 문단별로 구분중");
+
+        // 1. 전체 문단에 대한 파싱 요청을 보냄
+        GeminiResponseDto response = geminiRestClient.post()
+                .body(MarkdownToParagraphGeminiRequestDto.from(markdown))
+                .retrieve()
+                .body(GeminiResponseDto.class);
+
+        log.info(response.toString());
+        String filePath = Paths.get("/Users/mj/Desktop/log/gemini_parsing.txt").toString();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+            writer.write(response.toString());
+        } catch (IOException e) {
+
+        }
+
+        // 2. response 를 매핑 후 return
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            List<String> list = mapper.readValue(
+                    response.candidates().getFirst().content().parts().getFirst().text(),
+                    new TypeReference<List<String>>() {}
+            );
+
+            return list;
+        } catch (IOException e) {
+            throw new RuntimeException("문자열 mapping 중 예외 발생");
+        }
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/PdfToMarkdownAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/PdfToMarkdownAdapter.java
@@ -1,0 +1,96 @@
+package org.gdsc.globook.infrastructure.adapter;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.PdfToMarkdownResponsePollingDto;
+import org.gdsc.globook.application.port.PdfToMarkdownPort;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PdfToMarkdownAdapter implements PdfToMarkdownPort {
+    private final RestClient pdfRestClient;
+    private final RestClient getMdRestClient;
+
+    @Override
+    public PdfToMarkdownResponseDto convertPdfToMarkdown(
+            MultipartFile file
+    ) {
+        Resource fileResource = null;
+
+        // 1. 파일을 Resource 로 변환
+        try {
+            fileResource = new ByteArrayResource(file.getBytes()) {
+                @Override
+                @NonNull
+                public String getFilename() {
+                    return file.getOriginalFilename();
+                }
+            };
+        } catch (IOException e) {
+            throw new RuntimeException("pdf to Byte 전환 중 예외 발생");
+        }
+
+        // 2. multipart/form-data 요청 바디 생성
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("file", fileResource)
+                .contentType(MediaType.APPLICATION_PDF);
+
+        // 3. RestClient 로 전송
+        PdfToMarkdownResponsePollingDto pollingDto = pdfRestClient.post()
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(builder.build())
+                .retrieve()
+                .body(PdfToMarkdownResponsePollingDto.class);
+
+        // 4. 성공했다면, polling 하여 PdfToMarkdownResponseDto 받아옴.
+        if(pollingDto.success()) {
+            log.info("pdf 마크다운 전환 성공 ---------- " + pollingDto.request_check_url());
+
+            String checkUrl = pollingDto.request_check_url();
+            PdfToMarkdownResponseDto response = null;
+
+            int maxTry = 30;
+            int intervalMs = 300;
+
+            for (int i = 0; i < maxTry; i++) {
+                log.info("polling ---------- " + i);
+
+                response = getMdRestClient.get()
+                        .uri(checkUrl)
+                        .retrieve()
+                        .body(PdfToMarkdownResponseDto.class);
+
+                if (response.markdown() != null) {
+                    break;
+                }
+                try {
+                    Thread.sleep(intervalMs);
+                } catch (InterruptedException e) {
+                    // 1) 현재 스레드의 interrupted 상태 복구
+                    Thread.currentThread().interrupt();
+
+                    // 2) 루프를 깔끔히 빠져나가거나 상위로 전파
+                    throw new RuntimeException("폴링 중 인터럽트됨");
+                }
+            }
+
+            return response;
+        } else {
+            log.info("pdf 마크다운 전환 실패 ---------- " + pollingDto.error());
+
+            throw new RuntimeException("마크다운 전환 실패");
+        }
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TTSAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TTSAdapter.java
@@ -1,0 +1,92 @@
+package org.gdsc.globook.infrastructure.adapter;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.gdsc.globook.application.dto.TTSRequestDto;
+import org.gdsc.globook.application.dto.TTSResponseDto;
+import org.gdsc.globook.application.dto.UploadPdfRequestDto;
+import org.gdsc.globook.application.dto.gemini.GeminiResponseDto;
+import org.gdsc.globook.application.dto.gemini.GeneralizeParagraphRequestDto;
+import org.gdsc.globook.application.port.TTSPort;
+import org.gdsc.globook.domain.type.ELanguage;
+import org.gdsc.globook.domain.type.EPersona;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Base64;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class TTSAdapter implements TTSPort {
+    @Value("${cloud.storage.bucket}")
+    private String BUCKET_NAME;
+    private final Storage storage;
+    private final RestClient ttsRestClient;
+    private final RestClient geminiRestClient;
+
+    @Override
+    public String convertTextToSpeech(
+            Long userId,
+            Long fileId,
+            String inputText,
+            Long paragraphId,
+            UploadPdfRequestDto request
+    ) {
+        // 1. 문자열을 일반화
+        inputText = generalizeString(inputText);
+
+        // 2. 일반화된 문자열에 대해 TTS
+        TTSRequestDto ttsRequestDto = TTSRequestDto.from(
+                inputText,
+                ELanguage.valueOf(request.targetLanguage()),
+                EPersona.valueOf(request.persona())
+        );
+
+        ResponseEntity<TTSResponseDto> response = ttsRestClient.post()
+                .body(ttsRequestDto)
+                .retrieve()
+                .toEntity(TTSResponseDto.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            return uploadAudio(
+                    userId,
+                    fileId,
+                    Base64.getDecoder().decode(response.getBody().audioContent()),
+                    "문단 번호" + paragraphId
+            );
+        } else {
+            throw new IllegalStateException("TTS API 호출 실패: " + response.getStatusCode()); // 커스텀 에러로 변경해야 함
+        }
+    }
+
+    private String uploadAudio(
+            Long userId,
+            Long fileId,
+            byte[] audio,
+            String audioName
+    ) {
+        UUID uuid = UUID.randomUUID();
+        String objectName = "user " + userId + "/" + "file " + fileId + "/audio/" + audioName + uuid + ".mp3";
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, objectName)
+                .setContentType("audio/mpeg")
+                .build();
+        storage.create(blobInfo, audio);
+
+        return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, objectName);
+    }
+
+    private String generalizeString(String markdown) {
+        GeminiResponseDto response = geminiRestClient.post()
+                .body(GeneralizeParagraphRequestDto.from(markdown))
+                .retrieve()
+                .body(GeminiResponseDto.class);
+
+        return response.candidates().getFirst().content().parts().getFirst().text();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
@@ -1,0 +1,143 @@
+package org.gdsc.globook.infrastructure.adapter;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.gemini.GeminiResponseDto;
+import org.gdsc.globook.application.dto.gemini.TranslateGeminiRequestDto;
+import org.gdsc.globook.application.port.TranslateMarkdownPort;
+import org.gdsc.globook.domain.type.ELanguage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
+    @Value("${cloud.storage.bucket}")
+    private String BUCKET_NAME;
+    private final Storage storage;
+    private final RestClient geminiRestClient;
+
+    @Override
+    public String translateMarkdown(
+            Long userId,
+            Long fileId,
+            PdfToMarkdownResponseDto requestDto,
+            ELanguage targetLanguage
+    ) {
+        log.info("이미지를 S3 저장 후 url 을 넘겨받는 중");
+        String markdown = convertImageToUrl(userId, fileId, requestDto);
+
+        String filePath_ = Paths.get("/Users/mj/Desktop/log/image_markdown.txt").toString();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath_))) {
+            writer.write(markdown);
+        } catch (IOException e) {
+
+        }
+
+        log.info("마크다운을 번역중");
+        // 마크다운을 번역중
+        GeminiResponseDto response = geminiRestClient.post()
+                .body(TranslateGeminiRequestDto.from(markdown + "\n\n\n TRANSLATE TO " + targetLanguage.getLanguage()))
+                .retrieve()
+                .body(GeminiResponseDto.class);
+
+        String filePath = Paths.get("/Users/mj/Desktop/log/gemini_translate.txt").toString();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+            writer.write(response.toString());
+        } catch (IOException e) {
+
+        }
+
+        return response.candidates().getFirst().content().parts().getFirst().text();
+    }
+
+
+    private String convertImageToUrl(
+            Long userId,
+            Long fileId,
+            PdfToMarkdownResponseDto request
+    ) {
+        String markdown = request.markdown();
+        Map<String, String> images = request.images();
+        Map<String, String> uploaded = new HashMap<>();
+
+        // 1. 전체 이미지 업로드
+        for (Map.Entry<String,String> entry : images.entrySet()) {
+            String fileName = entry.getKey();
+            String base64Body = entry.getValue();
+
+            byte[] data = Base64.getDecoder().decode(base64Body);
+            String url  = uploadImage(userId, fileId, data, fileName);
+            uploaded.put(fileName, url);
+        }
+
+        // 2. 마크다운에서 파일명을 url 로 치환
+        for (Map.Entry<String,String> entry : uploaded.entrySet()) {
+            String fileName = Pattern.quote(entry.getKey());
+            String url = entry.getValue();
+
+            markdown = markdown.replaceAll("!\\[[^\\]]*]\\(" + fileName + "\\)", "![](" + url + ")");
+        }
+
+        // 테스트용 파일 생성 구문. 배포시 지울 예정
+        try {
+            Files.write(
+                    Path.of("/Users/mj/Downloads/result.md"),
+                    markdown.getBytes(),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("파일 생성중 예외 발생");
+        }
+
+        return markdown;
+    }
+
+    private String uploadImage(
+            Long userId,
+            Long fileId,
+            byte[] image,
+            String imageName
+    ) {
+        UUID uuid = UUID.randomUUID();
+        String objectName = "user " + userId + "/" + "file " + fileId + "/image/" + imageName + uuid + ".mp3";
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, objectName)
+                .setContentType(probeContentType(imageName))
+                .build();
+        storage.create(blobInfo, image);
+
+        return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, objectName);
+    }
+
+    private String probeContentType(String name) {
+        String ext = name.substring(name.lastIndexOf('.') + 1).toLowerCase();
+        return switch (ext) {
+            case "png"  -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif"  -> "image/gif";
+            case "bmp"  -> "image/bmp";
+            case "webp" -> "image/webp";
+            default     -> "application/octet-stream";
+        };
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/presentation/controller/ParagraphController.java
+++ b/globook_server/src/main/java/org/gdsc/globook/presentation/controller/ParagraphController.java
@@ -1,0 +1,63 @@
+package org.gdsc.globook.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.gdsc.globook.application.dto.PdfToMarkdownPollingRequestDto;
+import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.UploadPdfRequestDto;
+import org.gdsc.globook.application.service.FileService;
+import org.gdsc.globook.application.service.ParagraphService;
+import org.gdsc.globook.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/file")
+public class ParagraphController {
+    private final FileService fileService;
+    private final ParagraphService paragraphService;
+
+    @PostMapping("/all")
+    public ResponseEntity<?> createParagraphForFile(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart(value = "file") MultipartFile file,
+            @RequestPart(value = "uploadPdfRequest")UploadPdfRequestDto request
+    ) {
+        // 1. 입력받은 pdf 기반으로 1차적으로 file 레코드 생성 (status 는 '업로드 중')
+        Long fileId = fileService.createFile(userId, file, request);
+
+        // 2. pdf 기반으로 마크다운 문자열 생성 & 정상적으로 생성됐다면 file 레코드 status 뱐걍
+        PdfToMarkdownResponseDto markdown = paragraphService.convertMarkdown(file, fileId);
+
+        // 3. 마크다운을 targetLanguage 로 번역 후 Paragraph 레코드 생성
+        paragraphService.createParagraphForFile(markdown, userId, fileId, request);
+
+        return ResponseEntity.ok("task done");
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<PdfToMarkdownResponseDto> createParagraphForFileUpload(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart(value = "file") MultipartFile file,
+            @RequestPart(value = "uploadPdfRequest")UploadPdfRequestDto request
+    ) {
+        // 1. 입력받은 pdf 기반으로 1차적으로 file 레코드 생성 (status 는 '업로드 중')
+        Long fileId = fileService.createFile(userId, file, request);
+
+        // 2. pdf 기반으로 마크다운 문자열 생성 & 정상적으로 생성됐다면 file 레코드 status 뱐걍
+        PdfToMarkdownResponseDto markdown = paragraphService.convertMarkdown(file, fileId);
+
+        return ResponseEntity.ok().body(markdown);
+    }
+
+    @PostMapping("/translate")
+    public ResponseEntity<?> createParagraphForFileTranslate(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody PdfToMarkdownPollingRequestDto request
+    ) {
+        // 3. 마크다운을 targetLanguage 로 번역 후 Paragraph 레코드 생성
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/presentation/request/ConvertPdfRequestDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/presentation/request/ConvertPdfRequestDto.java
@@ -1,0 +1,6 @@
+package org.gdsc.globook.presentation.request;
+
+public record ConvertPdfRequestDto(
+        String langs
+) {
+}


### PR DESCRIPTION
## Related Issues
Link the issues this PR resolves.

- Resolves: #32 

## Description
This PR implements a full processing pipeline that converts uploaded PDF files into structured multilingual content. The pipeline includes:
- Converting PDFs to Markdown using an open-source library
- Segmenting Markdown content into paragraph entities
- Generating and storing audio metadata for each paragraph
- Translating the full Markdown content into a target language
- Repeating paragraph segmentation and audio metadata generation for the translated content
This lays the foundation for a rich, multilingual content experience with both textual and auditory elements.

## Tasks
List the tasks completed in this PR.
- Integrated PDF-to-Markdown conversion using a reliable open-source tool
- Implemented Markdown parser to segment content into Paragraph entities
- Generated and persisted audio metadata (e.g., file path, duration) for each paragraph
- Added translation logic for full Markdown text using target language
- Re-applied paragraph and audio processing logic for translated content

## Additional Notes
- All generated artifacts (Markdown, audio metadata, translated paragraphs) are traceable and linked to the original source for clarity and maintenance

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
