### PR TITLE
Feature/#48   implement polling based pdf upload api

### DIFF
--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResultDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/PdfToMarkdownResultDto.java
@@ -1,0 +1,22 @@
+package org.gdsc.globook.application.dto;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+@Builder
+public record PdfToMarkdownResultDto(
+        String markdown,
+        Boolean success,
+        Map<String, String> images,
+        Long fileId
+) {
+    public static PdfToMarkdownResultDto of(PdfToMarkdownResponseDto pdfToMarkdownResponseDto, Long fileId) {
+        return PdfToMarkdownResultDto.builder()
+                .markdown(pdfToMarkdownResponseDto.markdown())
+                .success(pdfToMarkdownResponseDto.success())
+                .images(pdfToMarkdownResponseDto.images())
+                .fileId(fileId)
+                .build();
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
@@ -6,8 +6,9 @@ public interface TTSPort {
     String convertTextToSpeech(
             Long userId,
             Long fileId,
-            String inputText,
             Long paragraphId,
-            UploadPdfRequestDto request
+            String inputText,
+            String targetLanguage,
+            String persona
     );
 }

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
@@ -1,13 +1,14 @@
 package org.gdsc.globook.application.port;
 
 import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.PdfToMarkdownResultDto;
 import org.gdsc.globook.domain.type.ELanguage;
 
 public interface TranslateMarkdownPort {
     String translateMarkdown(
             Long userId,
             Long fileId,
-            PdfToMarkdownResponseDto markdown,
+            PdfToMarkdownResultDto markdown,
             ELanguage targetLanguage
     );
 }

--- a/globook_server/src/main/java/org/gdsc/globook/application/service/FileService.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/service/FileService.java
@@ -30,7 +30,8 @@ public class FileService {
     public Long createFile(
             Long userId,
             MultipartFile file,
-            UploadPdfRequestDto request
+            String targetLanguage,
+            String persona
     ) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(GlobalErrorCode.NOT_FOUND_USER));
@@ -40,9 +41,9 @@ public class FileService {
                 File.create(
                         file.getOriginalFilename(),
                         user,
-                        EPersona.valueOf(request.persona()),
+                        EPersona.valueOf(persona),
                         0L,
-                        ELanguage.valueOf(request.targetLanguage())
+                        ELanguage.valueOf(targetLanguage)
                 )
         ).getId();
     }
@@ -67,5 +68,13 @@ public class FileService {
                 .toList();
 
         return PDFListResponseDto.of(uploadedFiles);
+    }
+
+    @Transactional
+    public void updateFileIndex(Long fileId, Long index) {
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> CustomException.type(GlobalErrorCode.NOT_FOUND_FILE));
+
+        file.updateIndex(index);
     }
 }

--- a/globook_server/src/main/java/org/gdsc/globook/core/exception/GlobalErrorCode.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/exception/GlobalErrorCode.java
@@ -21,6 +21,7 @@ public enum GlobalErrorCode implements ErrorCode{
     ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 데이터입니다."),
     NOT_FOUND_USER_BOOK(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자 도서입니다."),
     INVALID_REQUEST_TYPE(HttpStatus.BAD_REQUEST, "잘못된 요청 타입입니다."),
+    INVALID_DIRECTION(HttpStatus.BAD_REQUEST, "잘못된 방향 요청입니다."),
 
     /**
      * 401 : 인증 실패

--- a/globook_server/src/main/java/org/gdsc/globook/domain/entity/File.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/entity/File.java
@@ -100,7 +100,11 @@ public class File {
     }
 
     public void updateStatusFail() {
+        this.fileStatus = EFileStatus.FAIL;
+    }
 
+    public void updateIndex(Long index) {
+        this.index = index;
     }
 
     public void updateMaxIndex(Long maxIndex) {

--- a/globook_server/src/main/java/org/gdsc/globook/domain/type/EFileStatus.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/type/EFileStatus.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum EFileStatus {
     UPLOAD("업로드중"),
     PROCESSING("번역중"),
-    READ("읽기");
+    READ("읽기"),
+    FAIL("실패");
 
     private final String status;
 }

--- a/globook_server/src/main/java/org/gdsc/globook/domain/type/EPersona.java
+++ b/globook_server/src/main/java/org/gdsc/globook/domain/type/EPersona.java
@@ -6,12 +6,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum EPersona {
-    ETHAN("ETHAN", "MALE", 1.0, 1.0),
-    LUNA("LUNA", "FEMALE", 1.0, 1.0),
-    KAI("KAI", "MALE", 1.0, 1.0),
-    SORA("SORA", "FEMALE", 1.0, 1.0),
+    ETHAN("ETHAN", "MALE", 0.7, 0.7),
+    LUNA("LUNA", "FEMALE", 1.3, 1.0),
+    KAI("KAI", "MALE", 1.3, 1.3),
+    SORA("SORA", "FEMALE", 1.0, 1.3),
     NOAH("NOAH", "MALE", 1.0, 1.0),
-    ARIA("ARIA", "FEMALE", 1.0, 1.0);
+    ARIA("ARIA", "FEMALE", 0.7, 0.7);
 
     private final String persona;
     private final String gender;

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TTSAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TTSAdapter.java
@@ -33,9 +33,10 @@ public class TTSAdapter implements TTSPort {
     public String convertTextToSpeech(
             Long userId,
             Long fileId,
-            String inputText,
             Long paragraphId,
-            UploadPdfRequestDto request
+            String inputText,
+            String targetLanguage,
+            String persona
     ) {
         // 1. 문자열을 일반화
         inputText = generalizeString(inputText);
@@ -43,8 +44,8 @@ public class TTSAdapter implements TTSPort {
         // 2. 일반화된 문자열에 대해 TTS
         TTSRequestDto ttsRequestDto = TTSRequestDto.from(
                 inputText,
-                ELanguage.valueOf(request.targetLanguage()),
-                EPersona.valueOf(request.persona())
+                ELanguage.valueOf(targetLanguage),
+                EPersona.valueOf(persona)
         );
 
         ResponseEntity<TTSResponseDto> response = ttsRestClient.post()

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
+import org.gdsc.globook.application.dto.PdfToMarkdownResultDto;
 import org.gdsc.globook.application.dto.gemini.GeminiResponseDto;
 import org.gdsc.globook.application.dto.gemini.TranslateGeminiRequestDto;
 import org.gdsc.globook.application.port.TranslateMarkdownPort;
@@ -39,7 +40,7 @@ public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
     public String translateMarkdown(
             Long userId,
             Long fileId,
-            PdfToMarkdownResponseDto requestDto,
+            PdfToMarkdownResultDto requestDto,
             ELanguage targetLanguage
     ) {
         log.info("이미지를 S3 저장 후 url 을 넘겨받는 중");
@@ -66,7 +67,7 @@ public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
     private String convertImageToUrl(
             Long userId,
             Long fileId,
-            PdfToMarkdownResponseDto request
+            PdfToMarkdownResultDto request
     ) {
         String markdown = request.markdown();
         Map<String, String> images = request.images();
@@ -100,7 +101,7 @@ public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
             String imageName
     ) {
         UUID uuid = UUID.randomUUID();
-        String objectName = "user" + userId + "/" + "file" + fileId + "/image/" + imageName + uuid + ".mp3";
+        String objectName = "user" + userId + "/" + "file" + fileId + "/image/" + imageName + uuid;
 
         BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, objectName)
                 .setContentType(probeContentType(imageName))


### PR DESCRIPTION
## Related Issues
Link the issues this PR resolves.

- Resolves: #48 

## Description
This PR implements multiple enhancements to improve the PDF-to-Markdown conversion pipeline, persona-specific TTS configurations, and robust error handling:
- Persona-specific TTS Configuration
  - Added customizable speakingRate and pitch fields to EPersona
  - Integrated these new fields into the audio generation logic to dynamically apply TTS parameters per persona
- Robust PDF Upload Error Handling
  - Added comprehensive error catching, logging, and response handling for scenarios where PDF uploads fail
- Polling-based API for PDF Uploads
  - Split existing PDF-to-Markdown upload flow into two APIs

## Tasks
- Added speakingRate and pitch properties to EPersona configuration
- Integrated persona-specific TTS logic with these properties
- Implemented comprehensive error handling around PDF upload logic
- Developed polling-based PDF upload endpoints (initial upload + polling API)

## Additional Notes
- Ensure proper environment configuration for new APIs
- Verify that client-side integrations adapt to the new polling mechanism

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
