### PR TITLE
Refactor#53 - Redesign Markdown to Paragraph flow

### DIFF
--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/MarkdownTest.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/MarkdownTest.java
@@ -1,0 +1,6 @@
+package org.gdsc.globook.application.dto;
+
+public record MarkdownTest(
+        String markdown
+) {
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/dto/ParagraphInfoResponseDto.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/dto/ParagraphInfoResponseDto.java
@@ -11,14 +11,20 @@ public record ParagraphInfoResponseDto(
         Long id,
         Long maxIndex,
         String title,
+        String type,
+        String imageUrl,
         String targetLanguage,
         String persona
 ) {
-    public static ParagraphInfoResponseDto of(Long id, Long maxIndex, String title, ELanguage targetLanguage, EPersona persona) {
+    public static ParagraphInfoResponseDto of(
+            Long id, Long maxIndex, String title, String type, String imageUrl, ELanguage targetLanguage, EPersona persona
+    ) {
         return ParagraphInfoResponseDto.builder()
                 .id(id)
                 .maxIndex(maxIndex)
                 .title(title)
+                .type(type)
+                .imageUrl(imageUrl)
                 .targetLanguage(String.valueOf(targetLanguage))
                 .persona(String.valueOf(persona))
                 .build();

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/ConvertImageToUrlPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/ConvertImageToUrlPort.java
@@ -1,0 +1,12 @@
+package org.gdsc.globook.application.port;
+
+import java.util.Map;
+
+public interface ConvertImageToUrlPort {
+    String convertImageToUrl(
+            Long userId,
+            Long fileId,
+            String markdown,
+            Map<String, String> images
+    );
+}

--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TranslateMarkdownPort.java
@@ -7,7 +7,7 @@ public interface TranslateMarkdownPort {
     String translateMarkdown(
             Long userId,
             Long fileId,
-            PdfToMarkdownResultDto markdown,
+            String markdown,
             ELanguage targetLanguage
     );
 }

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/GCSImageToUrlConverter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/GCSImageToUrlConverter.java
@@ -1,0 +1,84 @@
+package org.gdsc.globook.infrastructure.adapter;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.gdsc.globook.application.port.ConvertImageToUrlPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GCSImageToUrlConverter implements ConvertImageToUrlPort {
+    @Value("${cloud.storage.bucket}")
+    private String BUCKET_NAME;
+    private final Storage storage;
+
+    @Override
+    public String convertImageToUrl(
+            Long userId,
+            Long fileId,
+            String markdown,
+            Map<String, String> images
+    ) {
+        log.info("이미지를 S3 저장 후 url 을 넘겨받는 중");
+        Map<String, String> uploaded = new HashMap<>();
+
+        // 1. 전체 이미지 업로드
+        for (Map.Entry<String,String> entry : images.entrySet()) {
+            String fileName = entry.getKey();
+            String base64Body = entry.getValue();
+
+            byte[] data = Base64.getDecoder().decode(base64Body);
+            String url = uploadImage(userId, fileId, data, fileName);
+            uploaded.put(fileName, url);
+        }
+
+        // 2. 마크다운에서 파일명을 url 로 치환
+        for (Map.Entry<String,String> entry : uploaded.entrySet()) {
+            String fileName = Pattern.quote(entry.getKey());
+            String url = entry.getValue();
+
+            markdown = markdown.replaceAll("!\\[[^\\]]*]\\(" + fileName + "\\)", "![](" + url + ")");
+        }
+
+        return markdown;
+    }
+
+    private String uploadImage(
+            Long userId,
+            Long fileId,
+            byte[] image,
+            String imageName
+    ) {
+        UUID uuid = UUID.randomUUID();
+        String objectName = "user" + userId + "/" + "file" + fileId + "/image/" + imageName + uuid;
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, objectName)
+                .setContentType(probeContentType(imageName))
+                .build();
+        storage.create(blobInfo, image);
+
+        return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, objectName);
+    }
+
+    private String probeContentType(String name) {
+        String ext = name.substring(name.lastIndexOf('.') + 1).toLowerCase();
+        return switch (ext) {
+            case "png"  -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif"  -> "image/gif";
+            case "bmp"  -> "image/bmp";
+            case "webp" -> "image/webp";
+            default     -> "application/octet-stream";
+        };
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/RegexBoundarySplitter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/RegexBoundarySplitter.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 @Slf4j
 @Component
 public class RegexBoundarySplitter implements MarkdownSplitterPort {
-    private static final int TOKEN_BUDGET = 5000;
+    private static final int TOKEN_BUDGET = 6000;
     // 분할 지점에 대한 정규표현식
     private static final Pattern SAFE = Pattern.compile(
             "(?m)^\\s*$|^#{1,6}\\s|^[-*+]\\s|^```"
@@ -26,22 +26,21 @@ public class RegexBoundarySplitter implements MarkdownSplitterPort {
         int i = 0;
         // 전체 문자열을 TOKEN_BUDGET 을 기준으로 반복적으로 분할
         while (start < md.length()) {
-            log.info("이거 왜이래 시발 ㅋㅋ. 반복횟수 : " + i);
+            log.info("문단 분리 횟수 : " + i);
 
             // 현재 위치에서 대략적인 종료 지점을 계산
             int approxEnd = approxIdx(md, start);
 
-            // ★ 검색 구간을 start ~ approxEnd 로 한정
+            // 검색 구간을 start ~ approxEnd 로 한정
             Matcher m = SAFE.matcher(md).region(start, approxEnd);
 
             int cut = -1;
-            while (m.find()) {          // 중복 탐색 걱정 없음
+            while (m.find()) {
                 cut = m.end();
             }
 
             // 안전한 지점이 없거나 너무 가까우면 강제로 자름
-            if (cut == -1 || cut <= start) {   // <= 로 방어
-                log.info("아니에요 여기서 좃됏어요");
+            if (cut == -1 || cut <= start) {
                 cut = approxEnd;
             }
 

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
@@ -31,21 +31,15 @@ import java.util.regex.Pattern;
 @Component
 @RequiredArgsConstructor
 public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
-    @Value("${cloud.storage.bucket}")
-    private String BUCKET_NAME;
-    private final Storage storage;
     private final RestClient geminiRestClient;
 
     @Override
     public String translateMarkdown(
             Long userId,
             Long fileId,
-            PdfToMarkdownResultDto requestDto,
+            String markdown,
             ELanguage targetLanguage
     ) {
-        log.info("이미지를 S3 저장 후 url 을 넘겨받는 중");
-        String markdown = convertImageToUrl(userId, fileId, requestDto);
-
         log.info("마크다운을 번역중");
         // 마크다운을 번역중
         GeminiResponseDto response = geminiRestClient.post()
@@ -63,63 +57,4 @@ public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
         return response.candidates().getFirst().content().parts().getFirst().text();
     }
 
-
-    private String convertImageToUrl(
-            Long userId,
-            Long fileId,
-            PdfToMarkdownResultDto request
-    ) {
-        String markdown = request.markdown();
-        Map<String, String> images = request.images();
-        Map<String, String> uploaded = new HashMap<>();
-
-        // 1. 전체 이미지 업로드
-        for (Map.Entry<String,String> entry : images.entrySet()) {
-            String fileName = entry.getKey();
-            String base64Body = entry.getValue();
-
-            byte[] data = Base64.getDecoder().decode(base64Body);
-            String url  = uploadImage(userId, fileId, data, fileName);
-            uploaded.put(fileName, url);
-        }
-
-        // 2. 마크다운에서 파일명을 url 로 치환
-        for (Map.Entry<String,String> entry : uploaded.entrySet()) {
-            String fileName = Pattern.quote(entry.getKey());
-            String url = entry.getValue();
-
-            markdown = markdown.replaceAll("!\\[[^\\]]*]\\(" + fileName + "\\)", "![](" + url + ")");
-        }
-
-        return markdown;
-    }
-
-    private String uploadImage(
-            Long userId,
-            Long fileId,
-            byte[] image,
-            String imageName
-    ) {
-        UUID uuid = UUID.randomUUID();
-        String objectName = "user" + userId + "/" + "file" + fileId + "/image/" + imageName + uuid;
-
-        BlobInfo blobInfo = BlobInfo.newBuilder(BUCKET_NAME, objectName)
-                .setContentType(probeContentType(imageName))
-                .build();
-        storage.create(blobInfo, image);
-
-        return String.format("https://storage.googleapis.com/%s/%s", BUCKET_NAME, objectName);
-    }
-
-    private String probeContentType(String name) {
-        String ext = name.substring(name.lastIndexOf('.') + 1).toLowerCase();
-        return switch (ext) {
-            case "png"  -> "image/png";
-            case "jpg", "jpeg" -> "image/jpeg";
-            case "gif"  -> "image/gif";
-            case "bmp"  -> "image/bmp";
-            case "webp" -> "image/webp";
-            default     -> "application/octet-stream";
-        };
-    }
 }

--- a/globook_server/src/main/java/org/gdsc/globook/presentation/controller/ParagraphController.java
+++ b/globook_server/src/main/java/org/gdsc/globook/presentation/controller/ParagraphController.java
@@ -1,7 +1,8 @@
 package org.gdsc.globook.presentation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.gdsc.globook.application.dto.*;
+import org.gdsc.globook.application.dto.ParagraphListResponseDto;
+import org.gdsc.globook.application.dto.PdfToMarkdownResultDto;
 import org.gdsc.globook.application.service.FileService;
 import org.gdsc.globook.application.service.ParagraphService;
 import org.gdsc.globook.core.annotation.AuthenticationPrincipal;

--- a/globook_server/src/main/java/org/gdsc/globook/presentation/controller/UserBookController.java
+++ b/globook_server/src/main/java/org/gdsc/globook/presentation/controller/UserBookController.java
@@ -65,7 +65,7 @@ public class UserBookController {
             @AuthenticationPrincipal Long userId,
             @PathVariable("bookId") Long bookId,
             @RequestBody UserPreferenceRequestDto userPreferenceRequestDto
-            ) {
+    ) {
         return BaseResponse.success(userBookService.addBookToUserDownload(userId, bookId, userPreferenceRequestDto));
     }
 


### PR DESCRIPTION
## Related Issues
Link the issues this PR resolves.

- Resolves: #53

## Description
This PR refactors the entire Markdown-to-Paragraph flow and updates the response DTO used in the paragraph reading API.

## Tasks
- Reimplement Markdown parsing & segmentation logic
- Apply new DTO to paragraph read API response

## Additional Notes
- Ready for extension into translated paragraphs and audio metadata

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules