### PR TITLE
Refactor/#55 - Add parallel Gemini response processing with retry backoff for 503 errors

### DIFF
--- a/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/port/TTSPort.java
@@ -1,7 +1,5 @@
 package org.gdsc.globook.application.port;
 
-import org.gdsc.globook.application.dto.UploadPdfRequestDto;
-
 public interface TTSPort {
     String convertTextToSpeech(
             Long userId,

--- a/globook_server/src/main/java/org/gdsc/globook/application/repository/ParagraphRepository.java
+++ b/globook_server/src/main/java/org/gdsc/globook/application/repository/ParagraphRepository.java
@@ -32,4 +32,6 @@ public interface ParagraphRepository extends JpaRepository<Paragraph, Long> {
             @Param("end") Long end
     );
 
+    @Query("SELECT p FROM Paragraph p WHERE p.file.id = :fileId")
+    List<Paragraph> findAllByFileId(@Param("fileId") Long fileId);
 }

--- a/globook_server/src/main/java/org/gdsc/globook/core/util/RetryUtils.java
+++ b/globook_server/src/main/java/org/gdsc/globook/core/util/RetryUtils.java
@@ -1,0 +1,43 @@
+package org.gdsc.globook.core.util;
+
+public class RetryUtils {
+
+    public interface Retryable<T> {
+        T execute() throws Exception;
+    }
+
+    public static <T> T retry(
+            Retryable<T> task,
+            int maxRetries,
+            long initialBackoffMillis,
+            boolean logFullStacktrace
+    ) {
+        int attempt = 0;
+
+        while (attempt < maxRetries) {
+            try {
+                return task.execute();
+            } catch (Exception e) {
+                attempt++;
+                if (attempt >= maxRetries) {
+                    if (logFullStacktrace) {
+                        throw new RuntimeException("최대 재시도 초과", e);
+                    } else {
+                        throw new RuntimeException("최대 재시도 초과: " + e.getMessage());
+                    }
+                }
+
+                long backoff = (long) Math.pow(2, attempt) * initialBackoffMillis;
+                System.err.printf("재시도 %d회차 - %s (다음 시도까지 %dms 대기)%n", attempt, e.getMessage(), backoff);
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("재시도 중 인터럽트 발생", ie);
+                }
+            }
+        }
+
+        throw new IllegalStateException("이 코드에 도달하면 안됨");
+    }
+}

--- a/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
+++ b/globook_server/src/main/java/org/gdsc/globook/infrastructure/adapter/TranslateMarkdownAdapter.java
@@ -1,31 +1,14 @@
 package org.gdsc.globook.infrastructure.adapter;
 
-import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.gdsc.globook.application.dto.PdfToMarkdownResponseDto;
-import org.gdsc.globook.application.dto.PdfToMarkdownResultDto;
 import org.gdsc.globook.application.dto.gemini.GeminiResponseDto;
 import org.gdsc.globook.application.dto.gemini.TranslateGeminiRequestDto;
 import org.gdsc.globook.application.port.TranslateMarkdownPort;
+import org.gdsc.globook.core.util.RetryUtils;
 import org.gdsc.globook.domain.type.ELanguage;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Pattern;
 
 @Slf4j
 @Component
@@ -40,21 +23,15 @@ public class TranslateMarkdownAdapter implements TranslateMarkdownPort {
             String markdown,
             ELanguage targetLanguage
     ) {
-        log.info("마크다운을 번역중");
-        // 마크다운을 번역중
-        GeminiResponseDto response = geminiRestClient.post()
-                .body(TranslateGeminiRequestDto.from(markdown + "\n\n\n TRANSLATE TO " + targetLanguage.getLanguage()))
-                .retrieve()
-                .body(GeminiResponseDto.class);
+        return RetryUtils.retry(() -> {
+            GeminiResponseDto response = geminiRestClient.post()
+                    .body(TranslateGeminiRequestDto.from(
+                            markdown + "\n\n\n TRANSLATE TO " + targetLanguage.getLanguage()
+                    ))
+                    .retrieve()
+                    .body(GeminiResponseDto.class);
 
-        String filePath = Paths.get("/Users/mj/Desktop/log/gemini_translate.txt").toString();
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
-            writer.write(response.toString());
-        } catch (IOException e) {
-
-        }
-
-        return response.candidates().getFirst().content().parts().getFirst().text();
+            return response.candidates().getFirst().content().parts().getFirst().text();
+        }, 5, 1000, true);
     }
-
 }


### PR DESCRIPTION
## Related Issues
Link the issues this PR resolves.

- Resolves: #55

## Description
This PR improves the robustness of Gemini integration by enabling parallel processing of large inputs and adding a retry mechanism with exponential backoff to handle 503 Service Unavailable errors gracefully.

## Tasks
- Process translation chunks in parallel using CompletableFuture
- Implement retry strategy with backoff on Gemini API failures

## Additional Notes
- Backoff policy helps avoid overloading Gemini when service is unstable

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules